### PR TITLE
Changed to use new API environment.

### DIFF
--- a/libs/utilities.js
+++ b/libs/utilities.js
@@ -11,8 +11,8 @@ const qs = require('qs');
  * @private
  */
 const requestUrl = function requestUrl(endpoint, token, options) {
-  const query = `?${options ? qs.stringify(options) : ''}&client_id=${token}`;
-  return `https://api.behance.net/v2/${endpoint}${query}`;
+  const query = `?${options ? qs.stringify(options) : ''}&api_key=${token}`;
+  return `https://cc-api-behance.adobe.io/v2/${endpoint}${query}`;
 };
 
 /**


### PR DESCRIPTION
The API endpoint has been updated on Behance to live at adobe.io. All new API keys granted from Adobe must run thru this environment otherwise they won't work.

It should be backwards compatible, but please check with the older api keys.